### PR TITLE
fix Glossary link

### DIFF
--- a/3-Advanced/Serving-Your-Team/11-How to Deal with Organizational Chaos.md
+++ b/3-Advanced/Serving-Your-Team/11-How to Deal with Organizational Chaos.md
@@ -8,4 +8,4 @@ Non-engineers can order people around but, in a typical software company, can cr
 
 If you are a leader, tell your people to do the same thing and tell them to ignore what anybody else tells them. This course of action is the best for you personally, and is the best for your company or project.
 
-Next [Glossary](../../4-Glossary.md)
+Next [Glossary](../../GLOSSARY.md)


### PR DESCRIPTION
simple fix, not much to say ;)

It seems like `4-Glossary.md` was renamed `GLOSSARY.md`