### PR TITLE
Add (optional but helpful) comma after conditional

### DIFF
--- a/en/2-Intermediate/Judgment/01-How to Tradeoff Quality Against Development Time.md
+++ b/en/2-Intermediate/Judgment/01-How to Tradeoff Quality Against Development Time.md
@@ -4,7 +4,7 @@ Software development is always a compromise between what the project does and ge
 
 If this happens your first responsibility is to inform your team and to clearly explain the cost of the decrease in quality. After all, your understanding of it should be much better than your boss's understanding. Make it clear what is being lost and what is being gained, and at what cost the lost ground will be regained in the next cycle. In this, the visibility provided by a good project plan should be helpful. If the quality tradeoff affects the quality assurance effort, point that out (both to your boss and quality assurance people). If the quality tradeoff will lead to more bugs being reported after the quality assurance period, point that out.
 
-If she still insists you should try to isolate the shoddiness into particular components that you can plan to rewrite or improve in the next cycle. Explain this to your team so that they can plan for it.
+If she still insists, you should try to isolate the shoddiness into particular components that you can plan to rewrite or improve in the next cycle. Explain this to your team so that they can plan for it.
 
 NinjaProgrammer at Slashdot sent in this gem:
 


### PR DESCRIPTION
Even unambiguous grammars can result in lots of backtracking.